### PR TITLE
Passed icePicApiKey as param to improve clarity with documentation

### DIFF
--- a/native-android-example/app/src/main/java/com/movmintdigitalfiat/icepic/IcePicWebViewActivity.java
+++ b/native-android-example/app/src/main/java/com/movmintdigitalfiat/icepic/IcePicWebViewActivity.java
@@ -43,8 +43,9 @@ public class IcePicWebViewActivity extends Activity {
         // Now there is some Javascript to execute within the initialized WebView
         // To do that we can create a custom interface class to keep the code clean and initialize custom class object to addJavascriptInterface()
         // addJavascriptInterface() expects two arguments, 1st is the custom interface class created and the interface name.
-        // This interface name have to be "flutter_inappwebview" which is provided by MovMint dev team
-        icePicWebView.addJavascriptInterface(new WebAppInterface(this, icePicWebView, icePicToken), "inappwebview");
+        // This interface name have to be "inappwebview" which is provided by MovMint dev team
+        icePicWebView.addJavascriptInterface(new WebAppInterface(this, icePicWebView, icePicToken,
+                Constants.icePicApiKey), "inappwebview");
 
     }
 }

--- a/native-android-example/app/src/main/java/com/movmintdigitalfiat/icepic/utils/WebAppInterface.java
+++ b/native-android-example/app/src/main/java/com/movmintdigitalfiat/icepic/utils/WebAppInterface.java
@@ -34,14 +34,16 @@ public class WebAppInterface {
     Context mContext;
     WebView icePicWebView;
     String icePicToken;
+    String icePicApiKey;
 
     OkHttpClient client = new OkHttpClient();
     Gson gson = new Gson();
 
-    public WebAppInterface(Context c, WebView webView, String icePicToken) {
+    public WebAppInterface(Context c, WebView webView, String icePicToken, String icePicApiKey) {
         mContext = c;
         icePicWebView = webView;
         this.icePicToken = icePicToken;
+        this.icePicApiKey = icePicApiKey;
     }
 
     // This method signature and the annotation is required
@@ -69,7 +71,7 @@ public class WebAppInterface {
                 // Use the Android WebView available method `evaluateJavascript()` to run the JS code snippet
                 // Send the `icepicToken` using the Web API window.postMessage()
                 // Expected argument should be in this format: {"icepicToken": "<your token>", "apikeyid": "<your api key id>"}
-                String jsonString = String.format("{\"icepicToken\": \"%s\", \"apikeyid\":\"%s\"}", icePicToken, Constants.icePicApiKey);
+                String jsonString = String.format("{\"icepicToken\": \"%s\", \"apikeyid\":\"%s\"}", icePicToken, icePicApiKey);
                 String workerJs = String.format("window.postMessage(%s);", jsonString);
                 icePicWebView.evaluateJavascript(workerJs, null);
             });


### PR DESCRIPTION
We were passing only `icePicToken` as param to interface class and within interface method directly accessing constant `icepicKey`. In order to improve readability with documentation `icepicKey` also passed as param.

From 

```
icePicWebView.addJavascriptInterface(new WebAppInterface(this, icePicWebView, icePicToken), "inappwebview");
```

To

```
icePicWebView.addJavascriptInterface(new WebAppInterface(this, icePicWebView, icePicToken,
                Constants.icePicApiKey), "inappwebview");
```